### PR TITLE
Change git clone url to public, read-only url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ header: This is Jekyll-Bootstrap
 
 <h3>1 - Install</h3>
 <pre><code>  $ gem install jekyll
-  $ git clone https://plusjade@github.com/plusjade/jekyll-bootstrap.git
+  $ git clone https://github.com/plusjade/jekyll-bootstrap.git
   $ cd jekyll-bootstrap
   $ jekyll --server</code></pre>
 <p>


### PR DESCRIPTION
I started running through the install instructions and got prompted for the repo password. 
Might be easier to give read-only repo URL instead?
