### PR TITLE
Add Atom rss feeds

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ var:
   archive_path: /archive.html
   categories_path : /categories.html
   tags_path : /tags.html
+  rss_path: /atom.xml
 
 production_url : http://username.github.com # or your custom domain name
 title : Jekyll Boostrap

--- a/atom.xml
+++ b/atom.xml
@@ -1,0 +1,27 @@
+---
+layout: nil
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+ 
+ <title>{{ site.title }}</title>
+ <link href="{{ site.production_url }}/atom.xml" rel="self"/>
+ <link href="{{ site.production_url }}"/>
+ <updated>{{ site.time | date_to_xmlschema }}</updated>
+ <id>{{ site.production_url }}</id>
+ <author>
+   <name>{{ site.author.name }}</name>
+   <email>{{ site.author.email }}</email>
+ </author>
+
+ {% for post in site.posts %}
+ <entry>
+   <title>{{ post.title }}</title>
+   <link href="{{ site.production_url }}{{ post.url }}"/>
+   <updated>{{ post.date | date_to_xmlschema }}</updated>
+   <id>h{{ site.production_url }}{{ post.id }}</id>
+   <content type="html">{{ post.content | xml_escape }}</content>
+ </entry>
+ {% endfor %}
+ 
+</feed>


### PR DESCRIPTION
Adds a default RSS feed for all items in `site.posts` at `/atom.xml`.
