### PR TITLE
Proposed: Add RSS link to nav bar

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,7 @@
 ---
 layout: nil
+title: RSS
+group: navigation
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Do you think this is how this should be handled? This will add the feed to the `navigation` group and it will be shown with the other items in the nav bar.

On my blog, I just include the RSS link in a sidebar that is in the default layout - but I think doing that won't work with themes.

You could also argue that by adding the `site.rss_path` that maybe we should just defer this decision to theme authors - each theme can choose how and where to show the RSS link (in a sidebar, with an icon, in the footer, etc)
