### PR TITLE
Broken link in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: Hello World!
 
 Read [Jekyll Quick Start](http://jekyllbootstrap.com/jekyll-quick-start.html)
 
-Complete usage and documentation available at: [Jekyll Bootstrap](http://jekyllboostrap.com)
+Complete usage and documentation available at: [Jekyll Bootstrap](http://jekyllbootstrap.com)
 
 ## Update Author Attributes
 


### PR DESCRIPTION
The link to jekyllbootstrap.com was incorrectly spelled as jekyllboostrap.com. 

It's the smallest thing possible, but this is my first ever contribution to an open source project. :)
