### PR TITLE
Another broken link in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Hello World!
 ---
 
-Read [Jekyll Quick Start](http://jekyllbootstrap.com/jekyll-quick-start.html)
+Read [Jekyll Quick Start](http://jekyllbootstrap.com/usage/jekyll-quick-start.html)
 
 Complete usage and documentation available at: [Jekyll Bootstrap](http://jekyllbootstrap.com)
 


### PR DESCRIPTION
http://jekyllbootstrap.com/usage/jekyll-quick-start.html was originally http://jekyllbootstrap.com/jekyll-quick-start.html
