### PR TITLE
Moving hard-coded "tagline" into _config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Thumbs.db
 !.gitkeep
 
 .rbenv-version
+.rvmrc

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ pygments: true
 # so be sure to set them if your theme uses them.
 #
 title : Jekyll Bootstrap
+tagline: Site Tagline
 author :
   name : Name Lastname
   email : blah@email.test

--- a/_includes/themes/tom/default.html
+++ b/_includes/themes/tom/default.html
@@ -33,7 +33,7 @@
       <div class="contact">
         <p>
           {{ site.author.name }}<br />
-          tagline<br />
+          {{ site.tagline }}<br />
           {{ site.author.email }}
         </p>
       </div>


### PR DESCRIPTION
The site tagline is currently a hard-coded value used inconsistently across the templates. This small patch moves it into _config.

As a side note, I also added .rvmrc (since rbenv is already covered) to gitignore for those of us still using Ruby Version Manager.
