### PR TITLE
Site-wide configuration option for tagline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Thumbs.db
 !.gitkeep
 
 .rbenv-version
+.rvmrc

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ pygments: true
 # so be sure to set them if your theme uses them.
 #
 title : Jekyll Bootstrap
+tagline: Site Tagline
 author :
   name : Name Lastname
   email : blah@email.test

--- a/_includes/themes/tom/default.html
+++ b/_includes/themes/tom/default.html
@@ -33,7 +33,7 @@
       <div class="contact">
         <p>
           {{ site.author.name }}<br />
-          tagline<br />
+          {{ site.tagline }}<br />
           {{ site.author.email }}
         </p>
       </div>


### PR DESCRIPTION
This updated pull request adds a configuration option for a site-wide tagline except for themes that are better suited to a per-page tag lines (eg Twitter theme).

Also, rvmrc added to gitignore.
