### PR TITLE
Adding Facebook Comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,10 @@ JB :
     intensedebate :
       account : 123abc
     facebook :
-      apikey : 123
+      appid : 123
+      num_posts: 5
+      width: 580
+      colorscheme: light
    
   # Settings for analytics helper
   # Set 'provider' to the analytics provider you want to use.

--- a/_includes/JB/comments-providers/facebook
+++ b/_includes/JB/comments-providers/facebook
@@ -1,1 +1,9 @@
-<h3>Facebook comments TODO!</h3>
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId={{ site.JB.comments.facebook.appid }}";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+<div class="fb-comments" data-href="{{ site.production_url }}" data-num-posts="{{ site.JB.comments.facebook.num_posts }}" data-width="{{ site.JB.comments.facebook.width }}" data-colorscheme="{{ site.JB.comments.facebook.colorscheme }}"></div>


### PR DESCRIPTION
I've added Facebook Comments along with the values in the config for the comment plugin. This includes width, colorscheme, app id and number of posts.

I set the default width to match the width of the default twitter theme. This could make other themes look odd (however Facebook Comments isn't the default in the config). As far as I know the only way to do 100% width for Facebook Comments is a width: 100% !important; on the classes for the comment widget. For now you can set the width in the config. Not sure if you want to leave it like that or maybe add an inline style to override the width (not a fan of it).

Let me know if you see any issues.
