### PR TITLE
Loading custom rake file from _rake/*.rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,3 +105,6 @@ def get_stdin(message)
   print message
   STDIN.gets.chomp
 end
+
+#Load custom rake scripts
+Dir['_rake/*.rake'].each { |r| load r }


### PR DESCRIPTION
This small patch allow to define custom rake task inside _rake folder (usefull for custom deploy task or for resource preprocessing).

It simply loads _rake/*.rake at the and of the Rakefile.
