### PR TITLE
Added option to specify a custom date when creating post

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,12 @@ task :post do
   abort("rake aborted: '#{CONFIG['posts']}' directory not found.") unless FileTest.directory?(CONFIG['posts'])
   title = ENV["title"] || "new-post"
   slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
-  date = (Time.parse(ENV['date']) || Time.now).strftime('%Y-%m-%d')
+  begin
+    date = (Time.parse(ENV['date']) || Time.now).strftime('%Y-%m-%d')
+  rescue Exception => e
+    puts "Error - date format must be YYYY-MM-DD, please check you typed it correctly!"
+    exit -1
+  end
   filename = File.join(CONFIG['posts'], "#{date}-#{slug}.#{CONFIG['post_ext']}")
   if File.exist?(filename)
     abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'


### PR DESCRIPTION
You can now pass a custom date when creating posts, like `rake post title="an amazing post" date="2011-01-01"`. I find it useful when merging content from a previous blog.
