### PR TITLE
Added error check for git system call.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -255,7 +255,7 @@ end # end namespace :theme
 def theme_from_git_url(url)
   tmp_path = JB::Path.build(:theme_packages, :node => "_tmp")
   system("git clone #{url} #{tmp_path}")
-  manifest = verify_manifest(tmp_path)
+  abort("system call to git failed!") if !system("git clone #{url} #{tmp_path}")
   new_path = JB::Path.build(:theme_packages, :node => manifest["name"])
   if File.exist?(new_path) && ask("=> #{new_path} theme package already exists. Override?", ['y', 'n']) == 'n'
     remove_dir(tmp_path)


### PR DESCRIPTION
Due to my issue with #38, I request adding a check if the git system call successfully executed. While this would be a very rare issue on linux, due to the fragmented environments that git runs in on windows (msys, cygwin, or just cmd), it is very possible that the git executable will not be found. 

This change simply adds an error message if the system call fails.
