### PR TITLE
Added: _includes/JB/list_item

### DIFF
--- a/_includes/JB/list_item
+++ b/_includes/JB/list_item
@@ -1,0 +1,16 @@
+{% comment %}<!--
+The list_item include is a listing helper.
+Usage:
+  list_item is included by pages_list to render each item.
+
+-->{% endcomment %}
+
+{% if site.JB.list_item.provider == "custom" %}
+  {% include custom/list_item %}
+{% else %}
+  {% if page.url == node.url %}
+  <li class="active"><a href="{{ BASE_PATH }}{{node.url}}" class="active">{{node.title}}</a></li>
+  {% else %}
+  <li><a href="{{ BASE_PATH }}{{node.url}}">{{node.title}}</a></li>
+  {% endif %}
+{% endif %}

--- a/_includes/JB/pages_list
+++ b/_includes/JB/pages_list
@@ -25,11 +25,7 @@ Usage:
 {% else %}
   {% for node in pages_list %}
     {% if group == null or group == node.group %}
-    	{% if page.url == node.url %}
-    	<li class="active"><a href="{{ BASE_PATH }}{{node.url}}" class="active">{{node.title}}</a></li>
-    	{% else %}
-    	<li><a href="{{ BASE_PATH }}{{node.url}}">{{node.title}}</a></li>
-    	{% endif %}
+      {% include JB/list_item %}
     {% endif %}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
(Aside: Jekyll Bootstrap is awesome!) 

As I setup my blog, I encountered a use case where I was setting up special a `page_list` for a particular group of pages (for example, `project` pages). I wanted a sort of index behavior, where I could include more things, like page summaries, taglines, etc. 

In essence, I boiled down what i wanted to do (and what enables me to do it) to the changes in this pull request. 

I noticed that tags_list is a bit more complicated. perhaps list_item could be ammended? not sure which way to proceed here.
