### PR TITLE
Resolved an issue preventing disabling comments for individual pages

### DIFF
--- a/_includes/JB/comments
+++ b/_includes/JB/comments
@@ -1,4 +1,4 @@
-{% if site.JB.comments.provider and page.JB.comments != false %}
+{% if site.JB.comments.provider and page.comments != false %}
 
 {% case site.JB.comments.provider %}
 {% when "disqus" %}


### PR DESCRIPTION
The if statement in `_includes/JB/comments` was looking for the `page.JB.comments` boolean instead of `page.comments` and this meant that adding `comments: false` to the YAML front matter of a page wasn't working.
