### PR TITLE
Added the wordpress_id value in Disqus code if present in the post

### DIFF
--- a/_includes/JB/comments-providers/disqus
+++ b/_includes/JB/comments-providers/disqus
@@ -2,6 +2,7 @@
 <script type="text/javascript">
     {% if site.safe == false %}var disqus_developer = 1;{% endif %}
     var disqus_shortname = '{{ site.JB.comments.disqus.short_name }}'; // required: replace example with your forum shortname
+    {% if page.wordpress_id %}var disqus_identifier = '{{page.wordpress_id}} {{site.production_url}}/?p={{page.wordpress_id}}';{% endif %}
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
I used Disqus in Wordpress before migrating to Jekyll and to let it work in the imported posts into Jekyll, this line is needed into Disqus code.

The wordpress_id value is imported from [Exitwp](https://github.com/thomasf/exitwp) and with this commit is used only if present.

Signed-off-by: Tommaso Visconti tommaso.visconti@gmail.com
