### PR TITLE
Add "description"-variable into new page/post pattern

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ task :post do
     post.puts "---"
     post.puts "layout: post"
     post.puts "title: \"#{title.gsub(/-/,' ')}\""
+	post.puts "description: \"\""
     post.puts "category: "
     post.puts "tags: []"
     post.puts "---"
@@ -88,6 +89,7 @@ task :page do
     post.puts "---"
     post.puts "layout: page"
     post.puts "title: \"#{title}\""
+	post.puts "description: \"\""
     post.puts "---"
     post.puts "{% include JB/setup %}"
   end


### PR DESCRIPTION
Since the meta-description tag seems to be the only meta-tag with an influence on the search-engine results I included it into the pattern for newly created posts/pages.

Code to include it's content into the page-header (using a `meta`-tag) is already existing in the `default.html`-page: https://github.com/plusjade/jekyll-bootstrap/blob/master/_includes/themes/twitter/default.html#L6
