### PR TITLE
Only list pages in pages_list with a title.

### DIFF
--- a/_includes/JB/pages_list
+++ b/_includes/JB/pages_list
@@ -24,12 +24,14 @@ Usage:
   {% include custom/pages_list %}
 {% else %}
   {% for node in pages_list %}
-    {% if group == null or group == node.group %}
-    	{% if page.url == node.url %}
-    	<li class="active"><a href="{{ BASE_PATH }}{{node.url}}" class="active">{{node.title}}</a></li>
-    	{% else %}
-    	<li><a href="{{ BASE_PATH }}{{node.url}}">{{node.title}}</a></li>
-    	{% endif %}
+    {% if node.title != null %}
+      {% if group == null or group == node.group %}
+      	{% if page.url == node.url %}
+      	<li class="active"><a href="{{ BASE_PATH }}{{node.url}}" class="active">{{node.title}}</a></li>
+      	{% else %}
+      	<li><a href="{{ BASE_PATH }}{{node.url}}">{{node.title}}</a></li>
+      	{% endif %}
+      {% endif %}
     {% endif %}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
The pages_list has a lot of empty bullet points, one for each page that doesn't have a page.title entry.

This patch ignores these when generating the pages.html list.
