### PR TITLE
Feedburner link is missing

### DIFF
--- a/_includes/JB/feedburner
+++ b/_includes/JB/feedburner
@@ -1,0 +1,3 @@
+{% if site.author.feedburner != null %}
+<link href="http://feeds.feedburner.com/{{ site.feedburner.id }}" rel="alternate" title="{{ site.title }}" type="application/atom+xml" />
+{% endif %}


### PR DESCRIPTION
Hi,

Awesome project, well done.

In _config.yml is a feedburner config variable, but it is not used in the template.

Just created a plugin (after reading the API, great docs), that creates the feedburner link if the above variable is set, so the plugin can be used acros different themes.

Keep up the god job!

Regards,
Wojciech
