### PR TITLE
Fixing inconstancy in theme pages vs posts.

### DIFF
--- a/_includes/themes/twitter/post.html
+++ b/_includes/themes/twitter/post.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} {% if page.tagline %} <small>{{ page.tagline }}</small>{% endif %}</h1>
 </div>
 
 <div class="row">


### PR DESCRIPTION
Change the h1 so that it picks up the tagline if it's defined in the post document.  Previously, it was fixed text.  This matches a similar line found in the page.html file for the theme.
