### PR TITLE
Fix that theme will not be overwritten if exists.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -197,8 +197,8 @@ namespace :theme do
     # Mirror each file into the framework making sure to prompt if already exists.
     packaged_theme_files.each do |filename|
       file_install_path = File.join(JB::Path.base, filename)
-      if File.exist? file_install_path
-        next if ask("#{file_install_path} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+      if File.exist? file_install_path and ask("#{file_install_path} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+        next
       else
         mkdir_p File.dirname(file_install_path)
         cp_r File.join(packaged_theme_path, filename), file_install_path


### PR DESCRIPTION
When some theme exists, "rake theme:install" will not overwrite the
previous theme files, even if we answer "y" to the "Do you want to
overwrite?" question. This pull request fixes this.
