### PR TITLE
Fix Twitter Post Template to Print Page Tagline

### DIFF
--- a/_includes/themes/twitter/post.html
+++ b/_includes/themes/twitter/post.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} <small>{{ page.tagline }}</small></h1>
 </div>
 
 <div class="row">


### PR DESCRIPTION
The default post template has a hard-coded tagline. I think we want to change it to accept the pages tagline, or leave it empty.
