### PR TITLE
Remove hardcoded tagline from twitter theme posts.html

### DIFF
--- a/_includes/themes/twitter/post.html
+++ b/_includes/themes/twitter/post.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} {% if page.tagline %} <small>{{ page.tagline }}</small>{% endif %}</h1>
 </div>
 
 <div class="row">


### PR DESCRIPTION
Replaces hardcoded tagline from twitter theme posts with the fix from @sway already applied to pages.html

See https://github.com/plusjade/jekyll-bootstrap/commit/e3e849e6e3232cd9df30ce64880095b7b002ae9c for original commit to pages.html.
