### PR TITLE
Google universal tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,10 +99,10 @@ JB :
   # Set 'provider' to false to turn analytics off globally.
   #        
   analytics :
-    provider : google-classic 
-    google-classic : 
+    provider : google_classic 
+    google_classic : 
         tracking_id : 'UA-123-12'
-    google-universal : 
+    google_universal : 
         tracking_id : 'UA-123-12'
         domain: 'github.com'
     getclicky :

--- a/_includes/JB/analytics
+++ b/_includes/JB/analytics
@@ -1,9 +1,9 @@
 {% if site.safe and site.JB.analytics.provider and page.JB.analytics != false %}
 
 {% case site.JB.analytics.provider %}
-{% when "google-classic" %}
+{% when "google_classic" %}
   {% include JB/analytics-providers/google-classic %}
-{% when "google-universal" %}
+{% when "google_universal" %}
   {% include JB/analytics-providers/google-universal %}
 {% when "getclicky" %}
   {% include JB/analytics-providers/getclicky %}

--- a/_includes/JB/analytics-providers/google-classic
+++ b/_includes/JB/analytics-providers/google-classic
@@ -1,6 +1,6 @@
 <script type="text/javascript">
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '{{ site.JB.analytics.google-classic.tracking_id }}']);
+  _gaq.push(['_setAccount', '{{ site.JB.analytics.google_classic.tracking_id }}']);
   _gaq.push(['_trackPageview']);
 
   (function() {

--- a/_includes/JB/analytics-providers/google-universal
+++ b/_includes/JB/analytics-providers/google-universal
@@ -4,7 +4,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '{{ site.JB.analytics.google-universal.tracking_id }}', '{{ site.JB.analytics.google-universal.domain }}');
+  ga('create', '{{ site.JB.analytics.google_universal.tracking_id }}', '{{ site.JB.analytics.google_universal.domain }}');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
Google Analytics has two options for tracking websites now. The legacy system which is now called 'classic' and the new system called 'universal tracking' which is in beta. This pull request adds support for the new universal tracking script and adds 'google_classic' and 'google_universal' as options in the providers section of the config file.
