### PR TITLE
Change title variable in title tag of default.html

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{{ page.title }}</title>
+    <title>
+      {% if page.title == site.title %}
+        {{ site.title }} {% if site.tagline %}{{ site.tagline }}{% endif %}
+      {% else %}
+        {{ page.title }} | {{ site.title }} {% if site.tagline %}{{ site.tagline }}{% endif %}
+      {% endif %}
+    </title>
     {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
     <meta name="author" content="{{ site.author.name }}">
 


### PR DESCRIPTION
I change the previous {{ page.title }} into new one so if the page is not home or the title of the page is not same as site title, it will display like "Page Title | Site Title".

In http://jekyllbootstrap.com/, it has been implemented. but not in default twitter theme.