### PR TITLE
Support for bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+# match github build server version
+# https://help.github.com/articles/using-jekyll-with-pages
+gem 'jekyll', '1.0.0'
+gem 'liquid', '2.5.0'
+gem 'redcarpet', '2.2.2'
+gem 'maruku', '0.6.1'
+gem 'rdiscount', '1.6.8'
+gem 'RedCloth', '4.2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.2.9)
+    classifier (1.3.3)
+      fast-stemmer (>= 1.0.0)
+    colorator (0.1)
+    commander (4.1.3)
+      highline (~> 1.6.11)
+    directory_watcher (1.4.1)
+    fast-stemmer (1.0.2)
+    highline (1.6.18)
+    jekyll (1.0.0)
+      classifier (~> 1.3)
+      colorator (~> 0.1)
+      commander (~> 4.1.3)
+      directory_watcher (~> 1.4.1)
+      kramdown (~> 0.14)
+      liquid (~> 2.3)
+      maruku (~> 0.5)
+      pygments.rb (~> 0.4.2)
+      safe_yaml (~> 0.7.0)
+    kramdown (0.14.2)
+    liquid (2.5.0)
+    maruku (0.6.1)
+      syntax (>= 1.0.0)
+    posix-spawn (0.3.6)
+    pygments.rb (0.4.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rdiscount (1.6.8)
+    redcarpet (2.2.2)
+    safe_yaml (0.7.1)
+    syntax (1.0.0)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth (= 4.2.9)
+  jekyll (= 1.0.0)
+  liquid (= 2.5.0)
+  maruku (= 0.6.1)
+  rdiscount (= 1.6.8)
+  redcarpet (= 2.2.2)


### PR DESCRIPTION
Instead of letting people manage different version of jekyll and other gems. I think it's better to utilize bundler's `Gemfile`. Then we can always same version of gems, and use same way of execute `jekyll` via `bundle exec jekyll`. What do you think?

Note: This Gemfile contains Jekyll 1.0.
