### PR TITLE
Update 'rake post' to support category on command line

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,12 +40,13 @@ module JB
   end #Path
 end #JB
 
-# Usage: rake post title="A Title" [date="2012-02-09"] [tags=[tag1, tag2]]
+# Usage: rake post title="A Title" [date="2012-02-09"] [tags=[tag1,tag2]] [category="category"]
 desc "Begin a new post in #{CONFIG['posts']}"
 task :post do
   abort("rake aborted: '#{CONFIG['posts']}' directory not found.") unless FileTest.directory?(CONFIG['posts'])
   title = ENV["title"] || "new-post"
   tags = ENV["tags"] || "[]"
+  category = ENV["category"] || ""
   slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
   begin
     date = (ENV['date'] ? Time.parse(ENV['date']) : Time.now).strftime('%Y-%m-%d')
@@ -64,7 +65,7 @@ task :post do
     post.puts "layout: post"
     post.puts "title: \"#{title.gsub(/-/,' ')}\""
     post.puts 'description: ""'
-    post.puts "category: "
+    post.puts "category: \"#{category.gsub(/-/,' ')}\""
     post.puts "tags: #{tags}"
     post.puts "---"
     post.puts "{% include JB/setup %}"


### PR DESCRIPTION
Updated comment.
Creating a post with multiple tags require no whitespaces between tags:
 rake post title="A Title" [date="2012-02-09"] ... tags=[tag1,tag2]
or quotes:
 rake post title="A Title" [date="2012-02-09"] ... tags="[tag1, tag2]"
