### PR TITLE
add duoshuo comment provider for chinese users

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,6 +92,8 @@ JB :
       num_posts: 5
       width: 580
       colorscheme: light
+    duoshuo :
+      short_name : jekyllbootstrap
    
   # Settings for analytics helper
   # Set 'provider' to the analytics provider you want to use.

--- a/_includes/JB/comments
+++ b/_includes/JB/comments
@@ -9,6 +9,8 @@
   {% include JB/comments-providers/intensedebate %}
 {% when "facebook" %}
   {% include JB/comments-providers/facebook %}
+{% when "duoshuo" %}
+  {% include JB/comments-providers/duoshuo %}
 {% when "custom" %}
   {% include custom/comments %}
 {% endcase %}

--- a/_includes/JB/comments-providers/duoshuo
+++ b/_includes/JB/comments-providers/duoshuo
@@ -1,0 +1,14 @@
+<!-- Duoshuo Comment BEGIN -->
+  <div class="ds-thread"{% if page.wordpress_id %} data-thread-key="{{page.wordpress_id}}"{% endif %}></div>
+<script type="text/javascript">
+var duoshuoQuery = {short_name:'{{ site.JB.comments.duoshuo.short_name }}'};
+  (function() {
+    var ds = document.createElement('script');
+    ds.type = 'text/javascript';ds.async = true;
+    ds.src = 'http://static.duoshuo.com/embed.js';
+    ds.charset = 'UTF-8';
+    (document.getElementsByTagName('head')[0] 
+    || document.getElementsByTagName('body')[0]).appendChild(ds);
+  })();
+  </script>
+<!-- Duoshuo Comment END -->


### PR DESCRIPTION
the reason is disqus and many other comment provider are too slow in china. 
duoshuo is a new comment provider in china(but not only open to china, it is becomming more and more popular in the world http://duoshuo.com) similar to disqus.  it can be installed on many platform,such as wordpress, mediawiki, dedecms, phpcms, discuz!x, joomla and so on

many jekyll users are using duoshuo too.
so, i think duoshuo should be added to jekyll-bootstrap for more users ;)