### PR TITLE
Comments form intense debate

### DIFF
--- a/_includes/JB/comments-providers/intensedebate
+++ b/_includes/JB/comments-providers/intensedebate
@@ -3,4 +3,5 @@ var idcomments_acct = '{{ site.JB.comments.intensedebate.account }}';
 var idcomments_post_id;
 var idcomments_post_url;
 </script>
-<script type="text/javascript" src="http://www.intensedebate.com/js/genericLinkWrapperV2.js"></script>
+<span id="IDCommentsPostTitle" style="display:none"></span>
+<script type="text/javascript" src="http://www.intensedebate.com/js/genericCommentWrapperV2.js"></script>

--- a/_includes/JB/comments-providers/intensedebate
+++ b/_includes/JB/comments-providers/intensedebate
@@ -3,5 +3,4 @@ var idcomments_acct = '{{ site.JB.comments.intensedebate.account }}';
 var idcomments_post_id;
 var idcomments_post_url;
 </script>
-<span id="IDCommentsPostTitle" style="display:none"></span>
 <script type="text/javascript" src="http://www.intensedebate.com/js/genericCommentWrapperV2.js"></script>


### PR DESCRIPTION
By default, the comment provider of JB for intensedebate display a links in the form "comments (0)".
The link itself has no effect by default, so it's kind of confusing for beginners who just set up the comments provider on the config and are hoping for a comments section.
With this commit, the comment form is displayed at the bottom of the post.



