### PR TITLE
Changes 'jekyll --server' to 'jekyll serve' in quick start guide.

### DIFF
--- a/_posts/usage/2011-10-31-jekyll-quick-start.md
+++ b/_posts/usage/2011-10-31-jekyll-quick-start.md
@@ -30,7 +30,7 @@ Once in the directory you'll run jekyll with server support:
 
 {% highlight bash %}
 $ cd USERNAME.github.com 
-$ jekyll --server
+$ jekyll serve
 # remember to change USERNAME to your GitHub username.
 {% endhighlight %}
 


### PR DESCRIPTION
Deprecation: The --server command has been replaced by the 'serve' subcommand.

:octocat: 
