### PR TITLE
Remove empty quotes when category is empty.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ task :post do
   title = ENV["title"] || "new-post"
   tags = ENV["tags"] || "[]"
   category = ENV["category"] || ""
-  category = category.empty? ? "" : "\"#{category.gsub(/-/,' ')}\""
+  category = "\"#{category.gsub(/-/,' ')}\"" if !category.empty?
   slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
   begin
     date = (ENV['date'] ? Time.parse(ENV['date']) : Time.now).strftime('%Y-%m-%d')


### PR DESCRIPTION
When category = ""

Should print "category: " to file, current behaviour prints "category: \"\"".

Latter creates an actual category, with a blank title. All posts created
since this update, without a category explicitly written in `rake`
command, or post directly edited, will belong to this category.

Creating the post:
![screenshot 2014-01-01 20 42 44](https://f.cloud.github.com/assets/318829/1830143/67f45b34-7325-11e3-86fe-3d3e79dcddd9.png)

The post:
![screenshot 2014-01-01 20 43 25](https://f.cloud.github.com/assets/318829/1830142/67ed154a-7325-11e3-988e-b488a2dc41b5.png)

The category:
![screenshot 2014-01-01 20 43 32](https://f.cloud.github.com/assets/318829/1830141/67e960da-7325-11e3-884a-16f0a4fed460.png)
