### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 # For more see: http://jekyllrb.com/docs/permalinks/
 permalink: /:categories/:year/:month/:day/:title 
 
+markdown: kramdown
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 pygments: true
 


### PR DESCRIPTION
Maruku (the default markdown interpreter) is now considered obsolete.