### PR TITLE
Use https for disqus embed include

### DIFF
--- a/_includes/JB/comments-providers/disqus
+++ b/_includes/JB/comments-providers/disqus
@@ -6,7 +6,7 @@
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>


### PR DESCRIPTION
Disqus embed will break if site is served over HTTPS otherwise, and no harm done if site is served over HTTP to include HTTPS script.
