### PR TITLE
Fix feeds

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -6,7 +6,7 @@ title : Atom Feed
 <feed xmlns="http://www.w3.org/2005/Atom">
  
  <title>{{ site.title }}</title>
- <link href="{{ site.production_url }}/{{ site.atom_path }}" rel="self"/>
+ <link href="{{ site.production_url }}/{{ site.JB.atom_path }}" rel="self"/>
  <link href="{{ site.production_url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
  <id>{{ site.production_url }}</id>

--- a/atom.xml
+++ b/atom.xml
@@ -19,7 +19,7 @@ title : Atom Feed
  <entry>
    <title>{{ post.title }}</title>
    <link href="{{ site.production_url }}{{ post.url }}"/>
-   <updated>{{ post.date | date_to_xmlschema }}</updated>
+   <updated>{% if post.updated == null %}{{ post.date | date_to_xmlschema }}{% else %}{{ post.updated | append: '@10am' | date_to_xmlschema }}{% endif %}</updated>
    <id>{{ site.production_url }}{{ post.id }}</id>
    <content type="html">{{ post.content | xml_escape }}</content>
  </entry>

--- a/atom.xml
+++ b/atom.xml
@@ -9,7 +9,7 @@ title : Atom Feed
  <link href="{{ site.production_url }}/{{ site.JB.atom_path }}" rel="self"/>
  <link href="{{ site.production_url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
- <id>{{ site.production_url }}</id>
+ <id>{{ site.production_url }}/</id>
  <author>
    <name>{{ site.author.name }}</name>
    <email>{{ site.author.email }}</email>

--- a/rss.xml
+++ b/rss.xml
@@ -8,7 +8,7 @@ title : RSS Feed
 <channel>
         <title>{{ site.title }}</title>
         <description>{{ site.title }} - {{ site.author.name }}</description>
-        <link>{{ site.production_url }}{{ site.rss_path }}</link>
+        <link>{{ site.production_url }}{{ site.JB.rss_path }}</link>
         <link>{{ site.production_url }}</link>
         <lastBuildDate>{{ site.time | date_to_xmlschema }}</lastBuildDate>
         <pubDate>{{ site.time | date_to_xmlschema }}</pubDate>

--- a/rss.xml
+++ b/rss.xml
@@ -4,11 +4,12 @@ title : RSS Feed
 ---
 
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
         <title>{{ site.title }}</title>
         <description>{{ site.title }} - {{ site.author.name }}</description>
         <link>{{ site.production_url }}{{ site.JB.rss_path }}</link>
+        <atom:link href="{{ site.production_url }}{{ site.JB.rss_path }}" rel="self" type="application/rss+xml" />
         <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
         <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
         <ttl>1800</ttl>

--- a/rss.xml
+++ b/rss.xml
@@ -9,8 +9,8 @@ title : RSS Feed
         <title>{{ site.title }}</title>
         <description>{{ site.title }} - {{ site.author.name }}</description>
         <link>{{ site.production_url }}{{ site.JB.rss_path }}</link>
-        <lastBuildDate>{{ site.time | date_to_xmlschema }}</lastBuildDate>
-        <pubDate>{{ site.time | date_to_xmlschema }}</pubDate>
+        <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+        <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
         <ttl>1800</ttl>
 
 {% for post in site.posts %}
@@ -19,7 +19,7 @@ title : RSS Feed
                 <description>{{ post.content | xml_escape }}</description>
                 <link>{{ site.production_url }}{{ post.url }}</link>
                 <guid>{{ site.production_url }}{{ post.id }}</guid>
-                <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
+                <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         </item>
 {% endfor %}
 

--- a/rss.xml
+++ b/rss.xml
@@ -9,7 +9,6 @@ title : RSS Feed
         <title>{{ site.title }}</title>
         <description>{{ site.title }} - {{ site.author.name }}</description>
         <link>{{ site.production_url }}{{ site.JB.rss_path }}</link>
-        <link>{{ site.production_url }}</link>
         <lastBuildDate>{{ site.time | date_to_xmlschema }}</lastBuildDate>
         <pubDate>{{ site.time | date_to_xmlschema }}</pubDate>
         <ttl>1800</ttl>


### PR DESCRIPTION
Update of RSS and Atom feeds to match standards.
* [RSS documentation](http://cyber.law.harvard.edu/rss/rss.html)
* [Atom documentation](http://tools.ietf.org/html/rfc4287)

## Changes:
* Updated self link to point site.JB.atom_path instead of  site.atom_path.
* Updated date formats to RFC 3339 for Atom and RFC 822 for RSS.

## Sources:
[http://cyber.law.harvard.edu/rss/rss.html](http://cyber.law.harvard.edu/rss/rss.html)
[http://pixelcog.com/blog/2013/jekyll-from-scratch-core-architecture](http://pixelcog.com/blog/2013/jekyll-from-scratch-core-architecture/#rss-and-atom-feeds)
[http://validator.w3.org](http://validator.w3.org)
[http://www.w3.org/2005/Atom](http://www.w3.org/2005/Atom)