### PR TITLE
Prepare for troubleshooting with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: "bundle exec jekyll build"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages'


### PR DESCRIPTION
This commit adds the two files mentioned at
https://help.github.com/articles/troubleshooting-github-pages-build-failures#configuring-a-third-party-service-to-display-jekyll-build-error-messages

Output: https://travis-ci.org/Mkaysi/jekyll-bootstrap

It seems that there is currently an issue with `_posts/core-samples/2011-12-29-jekyll-introduction.md` (see link).