### PR TITLE
fix deprecation warning; add markdown interpreter selector

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,8 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
+highlighter: true
+markdown: kramdown
 
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.


### PR DESCRIPTION
Changes:

* change pygments to highlighter to remove deprecation warning
* add markdown field to select new interpreter

See https://help.github.com/articles/migrating-your-pages-site-from-maruku for details on the new markdown interpreter.  If this field is not specified, GitHub Pages will default to maruku, which does not always compile valid markdown cleanly.

Change was validated using the configuration steps specified in https://help.github.com/articles/using-jekyll-with-pages and then running `bundle exec jekyll serve`.