### PR TITLE
fixing issue#225(deprecation warning)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
+highlighter: pygments
 
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.

--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 title : Atom Feed
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/rss.xml
+++ b/rss.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 title : RSS Feed
 ---
 


### PR DESCRIPTION
I did following two things:
1,_config.yml; change "pygments: true" to "highlighter: pygments"
2,rss.xml&atom.xml; change "Layout: nil" to "Layout: null"

Comparing to pull request aimed at issue[#223](https://github.com/plusjade/jekyll-bootstrap/pull/223),instead of explicitly adding markdown intepreter (`markdown:kramdown`),  I did nothing because in practice I used 'redcarpet'  intepreter.I'd rather do nothing instead of doing something that I am not sure what consequence would occur.
Besides, I changed rss.xml and atom.xml.
