### PR TITLE
Fixed the problem on displaying icons.

### DIFF
--- a/_includes/themes/bootstrap-3/post.html
+++ b/_includes/themes/bootstrap-3/post.html
@@ -13,7 +13,7 @@
 
   {% unless page.categories == empty %}
     <ul class="tag_box inline">
-      <li><i class="glyphicon-open"></i></li>
+      <li><i class="glyphicon glyphicon-open"></i></li>
       {% assign categories_list = page.categories %}
       {% include JB/categories_list %}
     </ul>
@@ -21,7 +21,7 @@
 
   {% unless page.tags == empty %}
     <ul class="tag_box inline">
-      <li><i class="glyphicon-tags"></i></li>
+      <li><i class="glyphicon glyphicon-tags"></i></li>
       {% assign tags_list = page.tags %}
       {% include JB/tags_list %}
     </ul>


### PR DESCRIPTION
Original one lead to a misbehavior on at least Chrome(Linux) and Firefox(Linux).

This problem is probable caused by forget to add 'glyphicon' to class for li.

The example on the [official bootstrap](http://getbootstrap.com/components/#glyphicons) site also have 'glyphicon' added to the class.

Before:
![err3](https://cloud.githubusercontent.com/assets/1883569/4539259/fc61d976-4dfa-11e4-944a-4b95d7438077.png)

After:
![err2](https://cloud.githubusercontent.com/assets/1883569/4539262/0055d0be-4dfb-11e4-8a49-4443eb207484.png)



