### PR TITLE
Fix glyphicons for categories and tags

### DIFF
--- a/_includes/themes/bootstrap-3/post.html
+++ b/_includes/themes/bootstrap-3/post.html
@@ -13,7 +13,7 @@
 
   {% unless page.categories == empty %}
     <ul class="tag_box inline">
-      <li><i class="glyphicon-open"></i></li>
+      <li><i class="glyphicon glyphicon-open"></i></li>
       {% assign categories_list = page.categories %}
       {% include JB/categories_list %}
     </ul>
@@ -21,7 +21,7 @@
 
   {% unless page.tags == empty %}
     <ul class="tag_box inline">
-      <li><i class="glyphicon-tags"></i></li>
+      <li><i class="glyphicon glyphicon-tags"></i></li>
       {% assign tags_list = page.tags %}
       {% include JB/tags_list %}
     </ul>


### PR DESCRIPTION
Added missing base "glyphicon" CSS class as described here: http://getbootstrap.com/components/#glyphicons-examples
