### PR TITLE
Let plugin take care of sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,8 @@ author :
 #
 production_url : http://username.github.io
 
+gems: ["jekyll-sitemap"]
+
 # All Jekyll-Bootstrap specific configurations are namespaced into this hash
 #
 JB :

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,8 +1,0 @@
----
-# Remember to set production_url in your _config.yml file!
-title : Sitemap
----
-{% for page in site.pages %}
-{{site.production_url}}{{ page.url }}{% endfor %}
-{% for post in site.posts %}
-{{site.production_url}}{{ post.url }}{% endfor %}


### PR DESCRIPTION
This removes the `sitemap.txt` in favor of using [**jekyll-sitemap**](https://github.com/jekyll/jekyll-sitemap)