### PR TITLE
escape all freeform text

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -5,19 +5,19 @@ title : Atom Feed
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
  
- <title>{{ site.title }}</title>
+ <title>{{ site.title | xml_escape }}</title>
  <link href="{{ site.production_url }}/{{ site.atom_path }}" rel="self"/>
  <link href="{{ site.production_url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
  <id>{{ site.production_url }}</id>
  <author>
-   <name>{{ site.author.name }}</name>
+   <name>{{ site.author.name | xml_escape }}</name>
    <email>{{ site.author.email }}</email>
  </author>
 
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="{{ site.production_url }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.production_url }}{{ post.id }}</id>

--- a/rss.xml
+++ b/rss.xml
@@ -6,8 +6,8 @@ title : RSS Feed
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
-        <title>{{ site.title }}</title>
-        <description>{{ site.title }} - {{ site.author.name }}</description>
+        <title>{{ site.title | xml_escape }}</title>
+        <description>{{ site.title | xml_escape }} - {{ site.author.name | xml_escape }}</description>
         <link>{{ site.production_url }}{{ site.rss_path }}</link>
         <link>{{ site.production_url }}</link>
         <lastBuildDate>{{ site.time | date_to_xmlschema }}</lastBuildDate>
@@ -16,7 +16,7 @@ title : RSS Feed
 
 {% for post in site.posts %}
         <item>
-                <title>{{ post.title }}</title>
+                <title>{{ post.title | xml_escape }}</title>
                 <description>{{ post.content | xml_escape }}</description>
                 <link>{{ site.production_url }}{{ post.url }}</link>
                 <guid>{{ site.production_url }}{{ post.id }}</guid>


### PR DESCRIPTION
Names, as well as page and site titles, can have & and ‘ as well as a few other reserved
characters. Escape them all for safety.