### PR TITLE
Bootstrap is no longer affiliated with Twitter

### DIFF
--- a/_includes/themes/bootstrap-3/default.html
+++ b/_includes/themes/bootstrap-3/default.html
@@ -82,7 +82,7 @@
       <div class="container">
         <p>&copy; {{ site.time | date: '%Y' }} {{ site.author.name }}
           with help from <a href="http://jekyllbootstrap.com" target="_blank" title="The Definitive Jekyll Blogging Framework">Jekyll Bootstrap</a>
-          and <a href="http://twitter.github.com/bootstrap/" target="_blank">Twitter Bootstrap</a>
+          and <a href="http://getbootstrap.com" target="_blank">Bootstrap</a>
         </p>
       </div>
     </div>

--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -55,7 +55,7 @@
       <footer>
         <p>&copy; {{ site.time | date: '%Y' }} {{ site.author.name }}
           with help from <a href="http://jekyllbootstrap.com" target="_blank" title="The Definitive Jekyll Blogging Framework">Jekyll Bootstrap</a>
-          and <a href="http://twitter.github.com/bootstrap/" target="_blank">Twitter Bootstrap</a>
+          and <a href="http://getbootstrap.com" target="_blank">Bootstrap</a>
         </p>
       </footer>
 


### PR DESCRIPTION
* "Twitter Bootstrap" => "Bootstrap", per http://getbootstrap.com/about/#brand
* Update Bootstrap links to http://getbootstrap.com

Refs https://github.com/twbs/bootstrap/issues/9899