### PR TITLE
Issue 290

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{% if page.theme.name %}{{ page.theme.name }}{% else %if %}{{layout.theme.name }}{% endif %}{% endcapture %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}

--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{% if page.theme.name %}{{ page.theme.name }}{% else %if %}{{layout.theme.name }}{% endif %}{% endcapture %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{% if page.theme.name %}{{ page.theme.name }}{% else if %}{{ layout.theme.name }}{% endif %}{% endcapture %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
Default ASSET_PATH fails for latest jekyll version #290
(https://github.com/plusjade/jekyll-bootstrap/issues/290)

solution: if page.theme.name unavailable (empty) use layout.theme.name