### PR TITLE
fix jekyll 3.0 path error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # This is the default format. 
 # For more see: http://jekyllrb.com/docs/permalinks/
-permalink: /:categories/:year/:month/:day/:title 
+permalink: /:categories/:year/:month/:day/:title/
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 highlighter: pygments


### PR DESCRIPTION
in jekyll 2.x `permalink: /:categories/:year/:month/:day/:title` = `/categories/year/month/day/title/`
but in jekyll 3.x  `permalink: /:categories/:year/:month/:day/:title` = `/categories/year/month/day/title`

add / to fix it