### PR TITLE
Upgrade to jekyll v3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.1"
+gem "jekyll-sitemap"
+gem "pygments.rb"

--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -17,7 +17,11 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
+      {% if layout.theme.name %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+      {% else %}
       {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% end %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
Hey, @plusjade & co!

This PR fixes #295 and #290, originally reported to the Jekyll team as https://github.com/jekyll/jekyll/issues/4450.

In Jekyll v3.0, all collection documents (and posts, which became collection documents in the "posts" collection) migrated to using `{{ layout }}` for any metadata defined in a layout. In v3.1, after spotting that we forgot pages (d'oh!), we migrated to using `{{ layout }}` for any metadata defined in a layout for pages as well. This latter migration seems to have broken Jekyll Bootstrap.

This PR migrates to using `{{ layout.theme.name }}` if it exists, and falls back to `{{ page.theme.name }}` if one exists. Does this seem like an acceptable fix? Thanks!